### PR TITLE
fix: make releases prerelease except for tag pushes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,5 +40,5 @@ runs:
           ${{ inputs.file }}.pdf
         tag_name: ${{ format('{0}-release', github.head_ref || github.ref_name || format('release-{0}', github.run_number)) }}
         draft: false
-        prerelease: ${{ github.event_name == 'pull_request_target' }}
+        prerelease: ${{ !startsWith(github.ref, 'refs/tags/') }}
         generate_release_notes: true


### PR DESCRIPTION
Change the prerelease condition to make all releases prerelease except when triggered by a tag push. This provides better distinction between official releases (via tags) and automated builds (via pushes or pull requests).