### PR TITLE
fix: improve parallel build reliability and error handling

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -93,43 +93,60 @@ runs:
         if [[ "${{ inputs.parallel }}" == "true" ]]; then
           echo "Building files in parallel..."
           pids=()
+          temp_dir=$(mktemp -d)
+          echo "Using temporary directory: $temp_dir"
           
           for file in "${TEX_FILES[@]}"; do
             file=$(echo $file | xargs)
+            # Sanitize filename for use in temp file names
+            safe_name=$(echo "$file" | tr '/' '_')
             echo "Starting build for: $file.tex"
             (
-              if ! latexmk ${{ inputs.latex_options }} "$file.tex"; then
-                echo "::error::Failed to build $file.tex"
-                echo "FAILED_$file" > "build_status_$file"
-                exit 1
+              if latexmk ${{ inputs.latex_options }} "$file.tex" 2>&1; then
+                echo "0" > "$temp_dir/exit_$safe_name"
+                echo "✓ Successfully built $file.tex"
               else
-                echo "SUCCESS_$file" > "build_status_$file"
+                echo "1" > "$temp_dir/exit_$safe_name"
+                echo "::error::Failed to build $file.tex"
+                exit 1
               fi
             ) &
             pids+=($!)
           done
           
-          # Wait for all builds to complete
-          for pid in "${pids[@]}"; do
-            if ! wait $pid; then
-              BUILD_FAILED=true
+          # Wait for all builds to complete and collect results
+          overall_success=true
+          for i in "${!pids[@]}"; do
+            pid=${pids[$i]}
+            file=$(echo "${TEX_FILES[$i]}" | xargs)
+            safe_name=$(echo "$file" | tr '/' '_')
+            
+            if wait $pid; then
+              echo "Process for $file.tex completed successfully"
+            else
+              echo "Process for $file.tex failed"
+              overall_success=false
+            fi
+            
+            # Double-check with exit code file
+            if [[ -f "$temp_dir/exit_$safe_name" ]]; then
+              exit_code=$(cat "$temp_dir/exit_$safe_name")
+              if [[ "$exit_code" != "0" ]]; then
+                echo "::error::Build failed for $file.tex (exit code: $exit_code)"
+                overall_success=false
+              fi
+            else
+              echo "::warning::No exit code file found for $file.tex"
+              overall_success=false
             fi
           done
           
-          # Check build status files
-          for file in "${TEX_FILES[@]}"; do
-            file=$(echo $file | xargs)
-            if [[ -f "build_status_$file" ]]; then
-              status=$(cat "build_status_$file")
-              if [[ "$status" == "FAILED_$file" ]]; then
-                echo "::error::Build failed for $file.tex"
-                BUILD_FAILED=true
-              else
-                echo "✓ Successfully built $file.tex"
-              fi
-              rm -f "build_status_$file"
-            fi
-          done
+          # Cleanup temporary directory
+          rm -rf "$temp_dir"
+          
+          if [[ "$overall_success" != "true" ]]; then
+            BUILD_FAILED=true
+          fi
         else
           echo "Building files sequentially..."
           for file in "${TEX_FILES[@]}"; do


### PR DESCRIPTION
## 🐛 Problem

Parallel build functionality was failing in CI with unreliable status tracking and race conditions.

## 🔧 Solution

### Key Improvements

1. **Secure Temporary Directory**
   - Use `mktemp -d` for isolated build status tracking
   - Prevents conflicts with repository files

2. **File Name Sanitization**
   - Convert slashes to underscores in temporary file names
   - Ensures compatibility with files in subdirectories like `test/sample`

3. **Robust Process Tracking**
   - Track both process IDs and exit codes
   - Double verification of build status

4. **Enhanced Error Handling**
   - More detailed logging for debugging
   - Comprehensive error detection and reporting

5. **Proper Cleanup**
   - Guaranteed removal of temporary directory
   - No leftover files in repository

### Technical Changes

- Replace simple status files with secure temporary directory approach
- Implement proper array indexing for PID-to-file mapping
- Add comprehensive exit code verification
- Improve error messages and logging

## 🧪 Test Plan

- [ ] Test single file builds (should remain unaffected)
- [ ] Test multiple file parallel builds
- [ ] Test multiple file sequential builds
- [ ] Verify error handling with non-existent files
- [ ] Confirm no temporary files are left behind

## 📝 Benefits

- Eliminates race conditions in parallel builds
- More reliable CI/CD pipeline
- Better error visibility for debugging
- Cleaner repository state after builds

This fix addresses the parallel build failures that were preventing successful CI runs.