### PR TITLE
fix: respect .latexmkrc configuration instead of forcing pdflatex

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   latex_options:
     description: 'Additional latexmk options'
     required: false
-    default: '-pdf -interaction=nonstopmode'
+    default: '-interaction=nonstopmode'
   release_name:
     description: 'Custom release name (optional)'
     required: false


### PR DESCRIPTION
## Summary
- Remove `-pdf` from default `latex_options` to allow `.latexmkrc` files in user repositories to control LaTeX compilation
- This enables proper support for Japanese LaTeX documents using uplatex + dvipdfmx
- Users can still explicitly set `-pdf` via `latex_options` parameter if pdflatex is needed

## Test plan
- [ ] Test with repository containing `.latexmkrc` configured for uplatex + dvipdfmx
- [ ] Test with repository without `.latexmkrc` (should still work with latexmk defaults)
- [ ] Test explicit `-pdf` option still forces pdflatex when needed