### PR TITLE
Fix ai-reviewer workflow by removing unsupported parameter

### DIFF
--- a/.github/workflows/ai-reviewer.yml
+++ b/.github/workflows/ai-reviewer.yml
@@ -27,4 +27,3 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           LANGUAGE: "Japanese"
           EXCLUDE_PATHS: "_build/**,deps/**,cover/**,log/**"
-          USE_SINGLE_COMMENT_REVIEW: "true"


### PR DESCRIPTION
## Summary
- Nasubikun/ai-reviewer@v1アクションから非サポートのUSE_SINGLE_COMMENT_REVIEWパラメータを削除
- ワークフロー実行時の警告を解消

## Details
Nasubikun/ai-reviewer@v1アクションは`USE_SINGLE_COMMENT_REVIEW`パラメータを公式にサポートしていません。このパラメータが設定されていると、ワークフロー実行時に以下のような警告が表示されます：

```
Warning: Unexpected input(s) 'USE_SINGLE_COMMENT_REVIEW', valid inputs are [...]
```

## Test plan
- [ ] ワークフローが正常に実行されることを確認
- [ ] 警告メッセージが表示されないことを確認
- [ ] AI reviewerが正常に動作することを確認

## Related
この問題はthesis-management-toolsリポジトリでも同様に発生し、修正済みです。本修正により、latex-release-actionリポジトリでも同じ問題が解決されます。