### PR TITLE
Fix container permission issues automatically

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,14 +30,16 @@ runs:
       run: |
         # Check if we can write to the temp directory, fix permissions if needed
         # This prevents EACCES errors when running in containers with non-root users
-        TEMP_DIR="/__w/_temp"
+        # Use RUNNER_TEMP if available, otherwise fall back to standard path
+        TEMP_DIR="${RUNNER_TEMP:-/__w/_temp}"
         if [ -d "$TEMP_DIR" ]; then
           TEST_FILE="$TEMP_DIR/.write_test_$$"
           if ! touch "$TEST_FILE" 2>/dev/null; then
             echo "Write permission issue detected, attempting to fix..."
-            chmod -R 777 "$TEMP_DIR" 2>/dev/null || sudo chmod -R 777 "$TEMP_DIR" 2>/dev/null || true
+            # Use chmod a+w (add write for all) instead of 777 for security
+            chmod -R a+w "$TEMP_DIR" 2>/dev/null || sudo chmod -R a+w "$TEMP_DIR" 2>/dev/null || true
             if touch "$TEST_FILE" 2>/dev/null; then
-              echo "✓ Permissions fixed successfully"
+              echo "Permissions fixed successfully"
               rm -f "$TEST_FILE"
             else
               echo "::warning::Could not fix permissions, but will attempt to continue"


### PR DESCRIPTION
## 概要

コンテナ環境で非rootユーザーを使用する際に発生するパーミッションエラーを自動的に解決します。

## 問題

ジョブレベルで `container` を指定して本アクションを使用すると、以下のエラーが発生していました：

```
Error: EACCES: permission denied, open '/__w/_temp/_runner_file_commands/save_state_...'
```

これは Docker イメージが非rootユーザー（例: `USER texuser`）を設定している場合、GitHub Actions ランナーの一時ディレクトリへの書き込み権限がないために発生します。

## 解決策

checkout ステップの前に、書き込み権限をチェックし、必要に応じて自動的にパーミッションを修正します。

### 実装の特徴

✅ **環境非依存**: コンテナ環境かどうかではなく、実際に書き込み可能かをテスト  
✅ **自動修復**: 権限がない場合は自動的に修正を試みる  
✅ **フェイルセーフ**: 修正できなくても警告のみで処理を継続  
✅ **ユーザー設定不要**: `options: --user root` の手動設定が不要に

## 変更内容

- `action.yml` に新しいステップを追加：
  - `/__w/_temp` への書き込みテスト
  - 書き込めない場合は `chmod -R 777` で修正
  - `sudo` でのフォールバック対応

## 影響を受けるリポジトリ

この修正により、以下のテンプレートで手動設定が不要になります：

- sotsuron-template
- poster-template
- latex-template
- sotsuron-report-template

## テスト方法

poster-template #2 (現在失敗中) でこのバージョンを使用してテスト予定。

## 関連

- Closes #27
- Related: sotsuron-report-template #13 (手動で回避策を適用済み)