### PR TITLE
Remove permission fix step for root-based containers

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,33 +25,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Fix permissions for GitHub Actions temp directories
-      shell: bash
-      run: |
-        # Check if we can write to the temp directory, fix permissions if needed
-        # This prevents EACCES errors when running in containers with non-root users
-        # Use RUNNER_TEMP if available, otherwise fall back to standard path
-        TEMP_DIR="${RUNNER_TEMP:-/__w/_temp}"
-        if [ -d "$TEMP_DIR" ]; then
-          TEST_FILE="$TEMP_DIR/.write_test_$$"
-          if ! touch "$TEST_FILE" 2>/dev/null; then
-            echo "Write permission issue detected, attempting to fix..."
-            # Change ownership to current user to allow creating subdirectories
-            # This is necessary for actions/checkout which creates _runner_file_commands/
-            sudo chown -R "$(id -u):$(id -g)" "$TEMP_DIR" 2>/dev/null || true
-            # Also set write permissions as fallback
-            sudo chmod -R a+w "$TEMP_DIR" 2>/dev/null || true
-            if touch "$TEST_FILE" 2>/dev/null; then
-              echo "Permissions fixed successfully"
-              rm -f "$TEST_FILE"
-            else
-              echo "::warning::Could not fix permissions, but will attempt to continue"
-            fi
-          else
-            rm -f "$TEST_FILE"
-          fi
-        fi
-
     - name: Checkout git repo
       uses: actions/checkout@v4
       with:


### PR DESCRIPTION
## Summary

texlive-ja-textlint:2025g が root ユーザー実行に戻ったため、permission fix ステップが不要になりました。このPRでは、そのステップを削除してアクションをシンプル化します。

## Changes

- `Fix permissions for GitHub Actions temp directories` ステップを削除
- sudo への依存を排除
- 2025c 以前の動作に戻る

## Rationale

1. **2025g では root で実行**: texlive-ja-textlint:2025g は root ユーザーで実行されるため、temp ディレクトリへの書き込み権限問題は発生しない
2. **シンプル化**: 不要な複雑さを排除し、メンテナンスを容易にする
3. **実績のある動作**: v2.2.0 まで問題なく動作していた方式に戻る

## Testing Plan

1. このPRをマージ後、v2.5.0 としてリリース
2. sotsuron-report-template で 2025g + v2.5.0 の組み合わせをテスト
3. 他のテンプレートリポジトリでも動作確認

## Related

- texlive-ja-textlint PR #40: Revert to root user execution
- texlive-ja-textlint Release 2025g