### PR TITLE
Fix GitHub token not being passed to Docker container

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,4 +33,11 @@ outputs:
 runs:
   using: 'docker'
   image: 'Dockerfile'
+  env:
+    INPUT_FILES: ${{ inputs.files }}
+    INPUT_LATEX_OPTIONS: ${{ inputs.latex_options }}
+    INPUT_RELEASE_NAME: ${{ inputs.release_name }}
+    INPUT_CLEANUP: ${{ inputs.cleanup }}
+    INPUT_PARALLEL: ${{ inputs.parallel }}
+    GH_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
## Issue

GitHub Release creation fails with error:
```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable
```

**Affected**: All repositories using v3.0.0 or v3.0.1

**Example failure**: https://github.com/smkwlab/k19rs999-sotsuron/actions/runs/19162517980

## Root Cause

Docker Container Actions don't automatically pass `github.token` to the container environment. The `gh` CLI requires `GH_TOKEN` environment variable to authenticate with GitHub API.

## Changes

### action.yml - Add env section

```yaml
runs:
  using: 'docker'
  image: 'Dockerfile'
  env:
    INPUT_FILES: ${{ inputs.files }}
    INPUT_LATEX_OPTIONS: ${{ inputs.latex_options }}
    INPUT_RELEASE_NAME: ${{ inputs.release_name }}
    INPUT_CLEANUP: ${{ inputs.cleanup }}
    INPUT_PARALLEL: ${{ inputs.parallel }}
    GH_TOKEN: ${{ github.token }}
```

## Benefits

1. **GitHub Release creation works**: `gh` CLI can now authenticate
2. **Explicit variable passing**: All inputs clearly mapped to environment variables
3. **No workflow changes needed**: Repositories automatically get the fix by updating action version

## Testing

- [ ] PDF build succeeds
- [ ] GitHub Release is created successfully
- [ ] Works with pull_request_target trigger
- [ ] Works with tag push trigger

## Migration

Users should update to v3.0.2 (or later) to fix release creation failures.

## Related

- Student repository failure: https://github.com/smkwlab/k19rs999-sotsuron/actions/runs/19162517980
- Docker Container Action docs: https://docs.github.com/en/actions/creating-actions/creating-a-docker-container-action#accessing-github-context-information