### PR TITLE
Fix Docker Container Action env context error

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,11 +33,4 @@ outputs:
 runs:
   using: 'docker'
   image: 'Dockerfile'
-  env:
-    INPUT_FILES: ${{ inputs.files }}
-    INPUT_LATEX_OPTIONS: ${{ inputs.latex_options }}
-    INPUT_RELEASE_NAME: ${{ inputs.release_name }}
-    INPUT_CLEANUP: ${{ inputs.cleanup }}
-    INPUT_PARALLEL: ${{ inputs.parallel }}
-    GH_TOKEN: ${{ github.token }}
 

--- a/test.sh
+++ b/test.sh
@@ -256,7 +256,7 @@ test_docker() {
     # Try different containers in order of preference
     # Note: Some containers may not have ARM64 images
     local CONTAINERS=(
-        "ghcr.io/smkwlab/texlive-ja-textlint:2025b-debian"
+        "ghcr.io/smkwlab/texlive-ja-textlint:2025i"
         "texlive/texlive:latest"
     )
     


### PR DESCRIPTION
Fixes critical bug where action.yml uses GitHub context expressions in `runs.env`, which is not supported in Docker Container Actions.

## Problem
v3.0.2 added `env` section with `${{ github.token }}` in action.yml, causing error:
```
Unrecognized named-value: 'github'. Located at position 1 within expression: github.token
```

## Root Cause
Docker Container Actions do not support GitHub context expressions (`${{ ... }}`) in the `runs.env` section. This is a limitation of the Docker Container Action type.

## Solution
Remove `env` section from action.yml completely. Docker Container Actions automatically:
- Pass `INPUT_*` environment variables from `inputs`
- Pass `GITHUB_*` environment variables from GitHub Actions context

Only `GH_TOKEN` needs to be set by users in their workflow files:

```yaml
- uses: smkwlab/latex-release-action@v3.0.3
  env:
    GH_TOKEN: ${{ github.token }}
  with:
    files: main
```

## Changes
- **action.yml**: Remove entire `env` section (8 lines deleted)
- **test.sh**: Update Docker image from `2025b-debian` to `2025i` (matches Dockerfile)

## Testing
- ✅ Tested with `./test.sh docker` - PDF generation succeeds
- ✅ Verified texlive-ja-textlint:2025i compatibility

## Documentation
README.md already documents the `GH_TOKEN` requirement in the usage examples.

Fixes #35