### PR TITLE
Fix git safe.directory error in Docker container

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+# Fix git safe.directory issue in Docker container
+git config --global --add safe.directory /github/workspace
+
 # Cleanup function for temporary directories
 cleanup_temp_dir() {
   if [[ -n "${TEMP_DIR}" ]] && [[ -d "${TEMP_DIR}" ]]; then


### PR DESCRIPTION
Fixes git ownership error that prevents GitHub Release creation in v3.0.3.

## Problem
Release creation fails with:
```
fatal: detected dubious ownership in repository at '/github/workspace'
Error: Failed to create release
```

## Root Cause
When GitHub Actions checks out the repository with `actions/checkout@v4`, the files are owned by the runner user. When the Docker container executes as root or a different user, Git refuses to operate on the repository for security reasons.

## Solution
Add `git config --global --add safe.directory /github/workspace` at the beginning of entrypoint.sh to mark the workspace as safe.

## Changes
- Add safe.directory configuration in entrypoint.sh

## Testing
Will be verified in actual GitHub Actions runs after merge.