### PR TITLE
Update CHANGELOG.md with missing releases v2.4.0-v3.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## [v3.0.4] - 2025-11-07
+
+### Fixed
+- Fix git safe.directory error in Docker container (#37)
+
+## [v3.0.3] - 2025-11-07
+
+### Fixed
+- Fix Docker Container Action env context error (#36)
+
+## [v3.0.2] - 2025-11-07
+
+### Fixed
+- Fix GitHub token not being passed to Docker container (#34)
+
+## [v3.0.1] - 2025-11-07
+
+### Fixed
+- Fix Alpine Linux compatibility for GitHub CLI installation (#33)
+
+## [v3.0.0] - 2025-11-07
+
+### Changed
+- **BREAKING**: Convert from composite action to Docker container action (#32)
+- Centralized TeXLive version management via container image
+
+### Migration
+- No workflow changes required for users
+- Action now uses `ghcr.io/smkwlab/texlive-ja-textlint` container
+- Improved isolation and consistency across environments
+
+## [v2.5.0] - 2025-11-04
+
+### Changed
+- Remove permission fix step for root-based containers (#30)
+
+## [v2.4.0] - 2025-11-04
+
+### Fixed
+- Fix permission handling for _runner_file_commands directory (#29)
+
 ## [v2.0.0] - 2025-02-15
 
 ### Added


### PR DESCRIPTION
## Summary

Updates CHANGELOG.md to document all releases from v2.4.0 to v3.0.4 that were missing from the changelog.

## Changes

### Added Entries

- **v2.4.0** (2025-11-04): Permission handling fix (#29)
- **v2.5.0** (2025-11-04): Remove permission fix step (#30)
- **v3.0.0** (2025-11-07): Docker Container Action conversion (**BREAKING CHANGE**, #32)
- **v3.0.1** (2025-11-07): Alpine Linux compatibility fix (#33)
- **v3.0.2** (2025-11-07): GitHub token passing fix (#34)
- **v3.0.3** (2025-11-07): Docker env context fix (#36)
- **v3.0.4** (2025-11-07): Git safe.directory fix (#37)

## Background

CHANGELOG.md was outdated, with the last entry being v2.0.0 (2025-02-15), while the repository has progressed to v3.0.4. This update brings the changelog up to date with all released versions.

## Special Note

v3.0.0 is a **BREAKING CHANGE** that converted the action from composite action to Docker container action, though it required no workflow changes for users.