### PR TITLE
Add v3.1.0 entry to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v3.1.0] - 2025-11-08
+
+### Changed
+- Release notes now use GitHub's auto-generated format with "What's Changed" and "Full Changelog" (#39)
+- Removed technical build details from release notes (Build options, Parallel build, Cleanup) (#39)
+
 ## [v3.0.4] - 2025-11-07
 
 ### Fixed


### PR DESCRIPTION
## Summary

Adds v3.1.0 release entry to CHANGELOG.md following the v3.1.0 release.

## Changes

### Added Entry

**v3.1.0** (2025-11-08):
- Release notes format improvement with GitHub auto-generated notes (#39)
- Removed technical build details from release notes (#39)

## Related

- Release: https://github.com/smkwlab/latex-release-action/releases/tag/v3.1.0
- PR #39: Auto-generated release notes implementation