### PR TITLE
Update base image to texlive-ja-textlint:2026a

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ brew install actionlint  # macOS
 5. Test both sequential and parallel builds
 
 ## Container Usage
-Recommended container: `ghcr.io/smkwlab/texlive-ja-textlint:2025b`
+Recommended container: `ghcr.io/smkwlab/texlive-ja-textlint:2026a`
 - Full TeX Live installation
 - Japanese language support
 - Pre-built for performance

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
-FROM ghcr.io/smkwlab/texlive-ja-textlint:2025i
+FROM ghcr.io/smkwlab/texlive-ja-textlint:2026a
+
+# Keep this base image tag in sync with latex-environment's devcontainer
+# (.devcontainer/devcontainer.json). Renovate (shared smkwlab/.github:latex
+# preset) tracks new texlive-ja-textlint releases.
 
 # Install GitHub CLI
-# Note: On GitHub Actions (amd64), texlive-ja-textlint:2025i uses Alpine Linux base
+# Note: On GitHub Actions (amd64), texlive-ja-textlint:2026a uses Alpine Linux base
 # Alpine package cleanup is omitted because:
 # - This container is ephemeral (created and destroyed per GitHub Actions job)
 # - Cleanup only affects image size, not runtime performance

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ on:
 jobs:
   build-latex:
     runs-on: ubuntu-latest
-    container: ghcr.io/smkwlab/texlive-ja-textlint:2025b
+    container: ghcr.io/smkwlab/texlive-ja-textlint:2026a
     permissions:
       contents: write  # Required for creating releases
     steps:
@@ -59,7 +59,7 @@ on:
 jobs:
   build-latex:
     runs-on: ubuntu-latest
-    container: ghcr.io/smkwlab/texlive-ja-textlint:2025b
+    container: ghcr.io/smkwlab/texlive-ja-textlint:2026a
     permissions:
       contents: write
     steps:
@@ -96,7 +96,7 @@ on:
 jobs:
   build-paper:
     runs-on: ubuntu-latest
-    container: ghcr.io/smkwlab/texlive-ja-textlint:2025b
+    container: ghcr.io/smkwlab/texlive-ja-textlint:2026a
     permissions:
       contents: write
     steps:
@@ -119,7 +119,7 @@ on:
 jobs:
   build-documents:
     runs-on: ubuntu-latest
-    container: ghcr.io/smkwlab/texlive-ja-textlint:2025b
+    container: ghcr.io/smkwlab/texlive-ja-textlint:2026a
     permissions:
       contents: write
     steps:
@@ -141,7 +141,7 @@ on:
 jobs:
   build-reports:
     runs-on: ubuntu-latest
-    container: ghcr.io/smkwlab/texlive-ja-textlint:2025b
+    container: ghcr.io/smkwlab/texlive-ja-textlint:2026a
     permissions:
       contents: write
     steps:
@@ -227,7 +227,7 @@ permissions:
 jobs:
   build-latex:
     runs-on: ubuntu-latest
-    container: ghcr.io/smkwlab/texlive-ja-textlint:2025b  # Recommended
+    container: ghcr.io/smkwlab/texlive-ja-textlint:2026a  # Recommended
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
resolve #64

`Dockerfile:1` が `texlive-ja-textlint:2025i` に固定されており、エコシステム本体（latex-environment devcontainer は `2026a`）と TeXLive 版数がずれていました。Action のビルド環境を学生のローカル環境に合わせ `2026a` に更新します。

## 変更
- `Dockerfile`: ベースイメージ `2025i` → `2026a`、コメントも追従。あわせて「latex-environment の devcontainer と同期する」運用コメントを追加
- `CLAUDE.md` / `README.md`: 例示・推奨コンテナの `2025b` → `2026a` に統一（リポジトリ内の版数記載を一掃）

## Renovate について
本リポジトリの `.github/renovate.json` は共有 preset（`github>smkwlab/.github:latex`）を継承しており、texlive-ja-textlint の新タグ追従はそちらで管理されます。そのため独自の regex manager 追加は行わず、Dockerfile に同期意図のコメントを残す形にしました。

## 検証
- ✅ リポジトリ内の `2025b` / `2025i` 残存: 0（CHANGELOG 除く）
- `2026a` はレジストリに存在する現行タグ（latex-environment と一致）

🤖 Generated with [Claude Code](https://claude.com/claude-code)