### PR TITLE
docs: add the v3.4.0 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v3.4.0] - 2026-08-04
+
+### Changed
+- Update base image to texlive-ja-textlint:2026a (#65)
+- Migrate code review to the org-standard ai-code-review workflow (#62)
+- Re-run AI review on push (#63)
+- Update usage examples to `@v3` in the READMEs (#66)
+
 ## [v3.3.0] - 2026-06-03
 
 ### Added


### PR DESCRIPTION
## 問題

`v3` は v3.3.0（2026-06-03）から動いておらず、以降 4 commit が main に入ったまま配布されていない。README の利用例が `@v3`（移動タグ）である以上、消費者はこれらを受け取れていない。

```
9f1b974 docs: update usage examples to @v3 and add v3.3.0 changelog entry (#66)
51c9fcb Update base image to texlive-ja-textlint:2026a (#65)
ad82276 ci: re-review on push (add synchronize) (#63)
8a146a6 Migrate code review to org-standard ai-code-review (#62)
```

実質的なのは #65 で、ベースイメージが `texlive-ja-textlint:2025i` → `2026a` に上がっている。学生文書のコンパイルに使われる TeX Live のバージョンが変わるため、配布して初めて意味を持つ変更である。

## 対応

CHANGELOG.md はリリースごとに維持されているので、v3.4.0 のエントリを追加する。merge 後に v3.4.0 を切り、`v3` を付け替える。

日付は CHANGELOG の既存エントリに合わせてタグ commit の日付を使う（v3.3.0 の場合、タグ commit が 2026-06-03、release の公開が 2026-06-05 で、CHANGELOG は前者を採っている）。

## 補足

`v3` を動かすと Actions の tarball キャッシュの影響を受けうるため、反映が怪しい場合は実行ログの `Download action repository` 行で解決された SHA を確認すること。移動タグを使う理由と線引きは smkwlab/latex-ecosystem#162 で整理中。
