### PR TITLE
build: move the base image to texlive-ja-textlint 2026d

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ name: Test LaTeX Release Action
 jobs:
   test-build:
     runs-on: ubuntu-latest
-    container: ghcr.io/smkwlab/texlive-ja-textlint:2025i
+    container: ghcr.io/smkwlab/texlive-ja-textlint:2026d
     permissions:
       contents: read
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ brew install actionlint  # macOS
 5. Test both sequential and parallel builds
 
 ## Container Usage
-Recommended container: `ghcr.io/smkwlab/texlive-ja-textlint:2026a`
+Recommended container: `ghcr.io/smkwlab/texlive-ja-textlint:2026d`
 - Full TeX Live installation
 - Japanese language support
 - Pre-built for performance

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM ghcr.io/smkwlab/texlive-ja-textlint:2026a
+FROM ghcr.io/smkwlab/texlive-ja-textlint:2026d
 
 # Keep this base image tag in sync with latex-environment's devcontainer
 # (.devcontainer/devcontainer.json). Renovate (shared smkwlab/.github:latex
 # preset) tracks new texlive-ja-textlint releases.
 
 # Install GitHub CLI
-# Note: On GitHub Actions (amd64), texlive-ja-textlint:2026a uses Alpine Linux base
+# Note: On GitHub Actions (amd64), texlive-ja-textlint:2026d uses Alpine Linux base
 # Alpine package cleanup is omitted because:
 # - This container is ephemeral (created and destroyed per GitHub Actions job)
 # - Cleanup only affects image size, not runtime performance

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ on:
 jobs:
   build-latex:
     runs-on: ubuntu-latest
-    container: ghcr.io/smkwlab/texlive-ja-textlint:2026a
+    container: ghcr.io/smkwlab/texlive-ja-textlint:2026d
     permissions:
       contents: write  # Required for creating releases
     steps:
@@ -59,7 +59,7 @@ on:
 jobs:
   build-latex:
     runs-on: ubuntu-latest
-    container: ghcr.io/smkwlab/texlive-ja-textlint:2026a
+    container: ghcr.io/smkwlab/texlive-ja-textlint:2026d
     permissions:
       contents: write
     steps:
@@ -96,7 +96,7 @@ on:
 jobs:
   build-paper:
     runs-on: ubuntu-latest
-    container: ghcr.io/smkwlab/texlive-ja-textlint:2026a
+    container: ghcr.io/smkwlab/texlive-ja-textlint:2026d
     permissions:
       contents: write
     steps:
@@ -119,7 +119,7 @@ on:
 jobs:
   build-documents:
     runs-on: ubuntu-latest
-    container: ghcr.io/smkwlab/texlive-ja-textlint:2026a
+    container: ghcr.io/smkwlab/texlive-ja-textlint:2026d
     permissions:
       contents: write
     steps:
@@ -141,7 +141,7 @@ on:
 jobs:
   build-reports:
     runs-on: ubuntu-latest
-    container: ghcr.io/smkwlab/texlive-ja-textlint:2026a
+    container: ghcr.io/smkwlab/texlive-ja-textlint:2026d
     permissions:
       contents: write
     steps:
@@ -227,7 +227,7 @@ permissions:
 jobs:
   build-latex:
     runs-on: ubuntu-latest
-    container: ghcr.io/smkwlab/texlive-ja-textlint:2026a  # Recommended
+    container: ghcr.io/smkwlab/texlive-ja-textlint:2026d  # Recommended
     permissions:
       contents: write
     steps:

--- a/README_ja.md
+++ b/README_ja.md
@@ -37,7 +37,7 @@ on:
 jobs:
   build-latex:
     runs-on: ubuntu-latest
-    container: ghcr.io/smkwlab/texlive-ja-textlint:2026a
+    container: ghcr.io/smkwlab/texlive-ja-textlint:2026d
     permissions:
       contents: write  # リリース作成に必要
     steps:
@@ -61,7 +61,7 @@ on:
 jobs:
   build-latex:
     runs-on: ubuntu-latest
-    container: ghcr.io/smkwlab/texlive-ja-textlint:2026a
+    container: ghcr.io/smkwlab/texlive-ja-textlint:2026d
     permissions:
       contents: write
     steps:
@@ -98,7 +98,7 @@ on:
 jobs:
   build-paper:
     runs-on: ubuntu-latest
-    container: ghcr.io/smkwlab/texlive-ja-textlint:2026a
+    container: ghcr.io/smkwlab/texlive-ja-textlint:2026d
     permissions:
       contents: write
     steps:
@@ -121,7 +121,7 @@ on:
 jobs:
   build-documents:
     runs-on: ubuntu-latest
-    container: ghcr.io/smkwlab/texlive-ja-textlint:2026a
+    container: ghcr.io/smkwlab/texlive-ja-textlint:2026d
     permissions:
       contents: write
     steps:
@@ -143,7 +143,7 @@ on:
 jobs:
   build-reports:
     runs-on: ubuntu-latest
-    container: ghcr.io/smkwlab/texlive-ja-textlint:2026a
+    container: ghcr.io/smkwlab/texlive-ja-textlint:2026d
     permissions:
       contents: write
     steps:
@@ -229,7 +229,7 @@ permissions:
 jobs:
   build-latex:
     runs-on: ubuntu-latest
-    container: ghcr.io/smkwlab/texlive-ja-textlint:2026a  # 推奨
+    container: ghcr.io/smkwlab/texlive-ja-textlint:2026d  # 推奨
     permissions:
       contents: write
     steps:

--- a/test.sh
+++ b/test.sh
@@ -256,7 +256,7 @@ test_docker() {
     # Try different containers in order of preference
     # Note: Some containers may not have ARM64 images
     local CONTAINERS=(
-        "ghcr.io/smkwlab/texlive-ja-textlint:2025i"
+        "ghcr.io/smkwlab/texlive-ja-textlint:2026d"
         "texlive/texlive:latest"
     )
     


### PR DESCRIPTION
## 問題

`Dockerfile` は自ら次のように書いている。

```dockerfile
FROM ghcr.io/smkwlab/texlive-ja-textlint:2026a

# Keep this base image tag in sync with latex-environment's devcontainer
# (.devcontainer/devcontainer.json). Renovate (shared smkwlab/.github:latex
# preset) tracks new texlive-ja-textlint releases.
```

しかし latex-environment の devcontainer は既に `2026c` で、**自分で宣言した不変条件を 2 世代ぶん破っていた**。Renovate は検出済みだったが、年内リビジョンが major 相当の扱いになるため自動マージ対象外で、Dependency Dashboard に滞留していた。

さらに調べると、他にも古い参照が残っていた。

| 箇所 | 変更前 | 影響 |
|---|---|---|
| `Dockerfile` | 2026a | action が実際に載るイメージ |
| `.github/workflows/test.yml` | **2025i** | CI がこの container で走っており、配布物と全く違う環境で試験していた |
| `test.sh` | **2025i** | ローカル統合テストの優先コンテナ |
| `README.md` / `README_ja.md` | 2026a × 各 6 箇所 | 利用者に提示している推奨タグ |
| `CLAUDE.md` | 2026a | Container Usage の記述 |

## 対応

すべて `2026d` に揃えた。`CHANGELOG.md` の履歴記述（`Update base image to texlive-ja-textlint:2026a (#65)`）は過去の事実なのでそのまま残している。

`2026d` の内容:

```
textlint                                   → 15.8.0
textlint-rule-preset-ja-technical-writing  7.0.0 → 12.0.2
textlint-rule-preset-ja-spacing            → 3.0.2
textlint-rule-no-mix-dearu-desumasu        5.0.0 → 6.0.4
node:24-trixie-slim                        @ae91dcc → @ac39e4b
```

## 範囲について

`test.yml` と `test.sh` の変更は「ベースイメージの同期」より一歩広い。含めた理由は、3 世代古い環境で試験しても配布物の検証にならないためで、これも同じ滞留の一形態と判断した。壊れれば CI が示すので、その場合は分離する。

## 検証

`yaml-lint` と `test-build` の成否で確認する。`test-build` は新しい container 上で実際に LaTeX ビルドを回すため、この変更の主要な検証になる。

## 関連

- smkwlab/texlive-ja-textlint での `2026d` 発行（イメージ publish 済み、`latest` も同一 digest）
- smkwlab/latex-environment#159 — devcontainer を `2026d` へ
- smkwlab/latex-template#57 — 新ルールで指摘が出る見本を である調 に修正（merge 済み）

textlint の挙動変化は配布前に実測済み。執筆済みの学生文書 3 本（日本語 13,236 文字）で指摘が完全一致し、LaTeX マークアップの誤検知は減る方向であることを確認している。
