### PR TITLE
docs: add the v3.5.0 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v3.5.0] - 2026-08-04
+
+### Changed
+- Update base image to texlive-ja-textlint:2026d (#68)
+
 ## [v3.4.0] - 2026-08-04
 
 ### Changed


### PR DESCRIPTION
## 背景

#68 でベースイメージを `texlive-ja-textlint:2026d` へ移したが、まだリリースされていない。最新タグ v3.4.0 のベースイメージは `2026a` のままで、`smkwlab/.github` の共有ワークフローもそこを pin している。学生リポジトリのビルド環境が devcontainer（2026d）から 2 世代遅れている状態を、リリースを切って解消する。

## 変更内容

v3.5.0 の CHANGELOG エントリを追加する。

## バージョンの選択

この action は API に破壊的変更が無い変更を minor で刻んできた（v3.4.0 も `2025x → 2026a` のベースイメージ更新を Changed として含む）。今回も同種の変更なので minor とする。

## マージ後の手順

1. `git tag v3.5.0 && git push origin v3.5.0`
2. 移動タグ `v3` を v3.5.0 へ付け替え
3. `gh release create v3.5.0`
4. `smkwlab/.github` の caller pin（`latex-build.yml` / `latex-build-modified.yml`）を v3.5.0 へ更新し、`v1` を付け替えて学生リポジトリへ配布
